### PR TITLE
デプロイ結果の Slack 通知を追加

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,3 +43,35 @@ jobs:
           firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_WAARU_K2SS }}'
           channelId: live
           projectId: waaru-k2ss
+
+
+  notify:
+    if: ${{ always() && (needs.build_and_deploy.result == 'success' || needs.build_and_deploy.result == 'failure') }}
+    needs:
+      - build_and_deploy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify to Slack
+        uses: slackapi/slack-github-action@v3.0.3
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            text: "${{ needs.build_and_deploy.result == 'success' && ':white_check_mark: Deploy succeeded' || ':x: Deploy failed' }}"
+            blocks:
+              - type: section
+                text:
+                  type: mrkdwn
+                  text: "${{ needs.build_and_deploy.result == 'success' && ':white_check_mark: *Deploy succeeded*' || ':x: *Deploy failed*' }}"
+              - type: section
+                fields:
+                  - type: mrkdwn
+                    text: "*Repository:*\n<${{ github.server_url }}/${{ github.repository }}|${{ github.repository }}>"
+              - type: actions
+                elements:
+                  - type: button
+                    text:
+                      type: plain_text
+                      text: View workflow
+                    url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    action_id: view_workflow

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,6 +11,9 @@ on:
     branches:
       - main
   workflow_dispatch:
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -43,7 +46,6 @@ jobs:
           firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_WAARU_K2SS }}'
           channelId: live
           projectId: waaru-k2ss
-
 
   notify:
     if: ${{ always() && (needs.build_and_deploy.result == 'success' || needs.build_and_deploy.result == 'failure') }}


### PR DESCRIPTION
## 概要
- Firebase Hosting / Cloudflare Pages の deploy workflow に Slack 通知を追加
- deploy の成功・失敗のみ Slack に通知
- 通知内容を成否アイコン、Repository リンク、Workflow リンクに整理

## 確認
- mise x actionlint -- actionlint 対象 workflow